### PR TITLE
Reduce size of Docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,34 +1,21 @@
-FROM ubuntu:22.04
+FROM alpine
 
-ARG H_GID=1000
 ARG H_UID=1000
+ARG H_GID=1000
 
-RUN apt update && \
-	apt install -y \
-		python3 \
-		python3-pip \
-		libcap2-bin
+RUN apk add --no-cache -X http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+      python3 py3-pip libcap libcap2 py3-dnslib
 
-RUN python3 -m pip install --no-cache-dir --upgrade pip
-
-# sytem and user setup 
+# setup system and user
 RUN ln -s /usr/bin/python3 /usr/local/bin/python \
-	&& addgroup --gid $H_GID user \
-	&& adduser user --uid $H_UID --ingroup user --gecos "" --home /home/user/ --disabled-password \
-	&& setcap CAP_NET_BIND_SERVICE=+eip /usr/bin/python3.10
-
- # install python packages
-RUN pip3 install --no-cache-dir \
-	dnslib
+      && addgroup --gid $H_GID user \
+      && adduser user --uid $H_UID --ingroup user --gecos "" --home /home/user/ --disabled-password \
+      && setcap CAP_NET_BIND_SERVICE=+eip "$(readlink -f /usr/bin/python3)"
 
 # install the code of the repo
+RUN python3 -m pip install --no-cache-dir --upgrade pip
 COPY ./docker/setup.py /home/user/
 RUN pip3 install -e /home/user/
-
-ENV PYTHONUNBUFFERED=1 
-
-# open port
-EXPOSE 53/udp
 
 # add source
 COPY --chown=user:user ./dns /home/user/dns/
@@ -37,4 +24,6 @@ COPY --chown=user:user ./run.py /home/user/
 # run
 USER user
 WORKDIR /home/user/
-CMD ["/usr/bin/python3","/home/user/run.py"]
+ENV PYTHONUNBUFFERED=1
+EXPOSE 53/udp
+CMD ["/usr/bin/python3", "/home/user/run.py"]


### PR DESCRIPTION
I just tried this project in combination with your radio_api. It's all working as expected, thanks a lot for maintaining these projects!

The Docker image is quite big, though: ~500MB is heavy for a simple DNS facade. This PR changes the base OS from Ubuntu to Alpine which reduces image size by ~400MB:

```
$ docker image ls | grep radio_dns
kimbtechnologies/radio_dns                              alpine                               b536597771ef   22 minutes ago   86.5MB
kimbtechnologies/radio_dns                              latest                               924400b0121b   4 days ago       491MB
```

In my environment, the Alpine image behaves as the Ubuntu image.